### PR TITLE
Update heltec_unofficial.h

### DIFF
--- a/src/heltec_unofficial.h
+++ b/src/heltec_unofficial.h
@@ -18,7 +18,9 @@
 #endif
 
 // 'PRG' Button
+#ifndef BUTTON
 #define BUTTON    GPIO_NUM_0
+#endif
 // LED pin & PWM parameters
 #define LED_PIN   GPIO_NUM_35
 #define LED_FREQ  5000


### PR DESCRIPTION
Custom PIN value for PROG button.

Boards T190, E230 have different PIN numbers - 21 

It would be nice to make it redefinable.  
