### PR TITLE
Add example for using PlatformIO as IDE

### DIFF
--- a/examples/platformio/LoRaWAN_TTN/.gitignore
+++ b/examples/platformio/LoRaWAN_TTN/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/platformio/LoRaWAN_TTN/.gitignore
+++ b/examples/platformio/LoRaWAN_TTN/.gitignore
@@ -1,5 +1,3 @@
 .pio
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/ipch
+.vscode
+

--- a/examples/platformio/LoRaWAN_TTN/platformio.ini
+++ b/examples/platformio/LoRaWAN_TTN/platformio.ini
@@ -21,3 +21,6 @@ lib_deps =
 	LoRaWAN_ESP32@1.1.0
 
 monitor_speed = 115200
+
+build_flags = 
+    -DHELTEC_WIRELESS_STICK ; add a build flag for the Heltec Wireless Stick / Heltec Wireless Stick Lite

--- a/examples/platformio/LoRaWAN_TTN/platformio.ini
+++ b/examples/platformio/LoRaWAN_TTN/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:heltec_wifi_lora_32_V3]
+platform = espressif32
+board = heltec_wifi_lora_32_V3
+framework = arduino
+platform_packages =
+    platformio/framework-arduinoespressif32
+
+lib_deps = 
+	Heltec_ESP32_LoRa_v3@0.9.1
+	jgromes/RadioLib@^6.6.0
+	LoRaWAN_ESP32@1.1.0
+
+monitor_speed = 115200

--- a/examples/platformio/LoRaWAN_TTN/src/main.cpp
+++ b/examples/platformio/LoRaWAN_TTN/src/main.cpp
@@ -1,0 +1,99 @@
+/**
+ * 
+ * FOR THIS EXAMPLE TO WORK, YOU MUST INSTALL THE "LoRaWAN_ESP32" LIBRARY USING
+ * THE LIBRARY MANAGER IN THE ARDUINO IDE.
+ * 
+ * This code will send a two-byte LoRaWAN message every 15 minutes. The first
+ * byte is a simple 8-bit counter, the second is the ESP32 chip temperature
+ * directly after waking up from its 15 minute sleep in degrees celsius + 100.
+ *
+ * If your NVS partition does not have stored TTN / LoRaWAN provisioning
+ * information in it yet, you will be prompted for them on the serial port and
+ * they will be stored for subsequent use.
+ *
+ * See https://github.com/ropg/LoRaWAN_ESP32
+*/
+
+#include <Arduino.h>
+// Pause between sends in seconds, so this is every 15 minutes. (Delay will be
+// longer if regulatory or TTN Fair Use Policy requires it.)
+#define MINIMUM_DELAY 900 
+
+// Heltec board-specific includes
+#define HELTEC_WIRELESS_STICK
+#include <heltec_unofficial.h>
+#include <LoRaWAN_ESP32.h>
+#include <RadioLib.h>
+
+LoRaWANNode* node;
+
+RTC_DATA_ATTR uint8_t count = 0;
+
+// Forward declaration of goToSleep function
+void goToSleep(); 
+
+void setup() {
+  heltec_setup();
+
+  // Obtain directly after deep sleep
+  // May or may not reflect room temperature, sort of. 
+  float temp = heltec_temperature();
+  Serial.printf("Temperature: %.1f °C\n", temp);
+
+  // initialize radio
+  Serial.println("Radio init");
+  int16_t state = radio.begin();
+  if (state != RADIOLIB_ERR_NONE) {
+    Serial.println("Radio did not initialize. We'll try again later.");
+    goToSleep();
+  }
+
+  node = persist.manage(&radio);
+
+  if (!node->isActivated()) {
+    Serial.println("Could not join network. We'll try again later.");
+    goToSleep();
+  }
+
+  // If we're still here, it means we joined, and we can send something
+
+  // Manages uplink intervals to the TTN Fair Use Policy
+  node->setDutyCycle(true, 1250);
+
+  uint8_t uplinkData[2];
+  uplinkData[0] = count++;
+  uplinkData[1] = temp + 100;
+
+  uint8_t downlinkData[256];
+  size_t lenDown = sizeof(downlinkData);
+
+  state = node->sendReceive(uplinkData, sizeof(uplinkData), 1, downlinkData, &lenDown);
+
+  if(state == RADIOLIB_ERR_NONE || state == RADIOLIB_LORAWAN_NO_DOWNLINK) {
+    Serial.println("Message sent");
+  } else {
+    Serial.printf("sendReceive returned error %d, we'll try again later.\n", state);
+  }
+
+  goToSleep();    // Does not return, program starts over next round
+
+}
+
+void loop() {
+  // This is never called. There is no repetition: we always go back to
+  // deep sleep one way or the other at the end of setup()
+}
+
+void goToSleep() {
+  Serial.println("Going to deep sleep now");
+  // allows recall of the session after deepsleep
+  persist.saveSession(node);
+  // Calculate minimum duty cycle delay (per FUP & law!)
+  uint32_t interval = node->timeUntilUplink();
+  // And then pick it or our MINIMUM_DELAY, whichever is greater
+  uint32_t delayMs = max(interval, (uint32_t)MINIMUM_DELAY * 1000);
+  Serial.printf("Next TX in %i s\n", delayMs/1000);
+  delay(100);  // So message prints
+  // and off to bed we go
+  heltec_deep_sleep(delayMs/1000);
+}

--- a/examples/platformio/LoRaWAN_TTN/src/main.cpp
+++ b/examples/platformio/LoRaWAN_TTN/src/main.cpp
@@ -19,8 +19,7 @@
 // longer if regulatory or TTN Fair Use Policy requires it.)
 #define MINIMUM_DELAY 900 
 
-// Heltec board-specific includes
-#define HELTEC_WIRELESS_STICK
+
 #include <heltec_unofficial.h>
 #include <LoRaWAN_ESP32.h>
 #include <RadioLib.h>

--- a/examples/platformio/platformio.md
+++ b/examples/platformio/platformio.md
@@ -1,0 +1,29 @@
+# Introduction
+
+[PlatformIO](https://platformio.org/) is a versatile and feature-rich development environment widely used for programming ESP microcontrollers, such as the [ESP32](https://www.espressif.com/en/products/socs/esp32) and [ESP8266](https://www.espressif.com/en/products/socs/esp8266). Unlike the [Arduino IDE](https://www.arduino.cc/en/software), which is often seen as beginner-friendly but limited in features, PlatformIO offers a more robust ecosystem with support for multiple platforms, integrated libraries, and tools like debugging and unit testing. It simplifies dependency management, automates library installations, and provides an advanced editor with IntelliSense, code completion, and version control integration. PlatformIO also allows more efficient compilation, build customization, and a seamless workflow across different operating systems, making it ideal for more complex projects and professional development setups.
+
+To enable the use of PlatformIO for this project, this directory contains code of an Arduino based example, adapted for PlatformIO.
+
+## How to Install PlatformIO
+
+PlatformIO can be installed either as a standalone IDE or as an extension for [Visual Studio Code](https://code.visualstudio.com/).
+
+### 1. Standalone Installation
+To install the standalone version of PlatformIO, download the installer for your operating system directly from the [official PlatformIO website](https://platformio.org/install/ide?install=vscode). This version comes bundled with everything needed for development, offering an all-in-one solution.
+
+### 2. Installing PlatformIO as a VSCode Extension
+If you prefer to use Visual Studio Code, you can install PlatformIO as an extension. Open VSCode and go to the Extensions view (`Ctrl+Shift+X` or `Cmd+Shift+X` on macOS). Search for "PlatformIO IDE" and click **Install**. Once installed, PlatformIO will integrate directly into VSCode, providing a powerful development environment.
+
+For more detailed instructions on installation, refer to the [official PlatformIO Installation Guide](https://platformio.org/install).
+
+## Migrating Arduino-based projects to PlatformIO
+
+When migrating Arduino-based projects to PlatformIO, you may encounter compatibility issues due to differences in how PlatformIO handles libraries, board configurations, and certain Arduino-specific functions. For example, PlatformIO uses its own library management system, so library versions may differ from those in the Arduino IDE, potentially causing compilation errors. Additionally, board definitions and settings like pin mappings or clock frequencies may need adjustments in the `platformio.ini` file to match the original Arduino setup. To resolve these issues, ensure that the correct libraries and versions are declared in your `platformio.ini` file and manually add any missing libraries or dependencies. 
+
+You can look at the Arduino IDE's compiler messages to find out which libraries and dependencies are used in a project. PlatformIO also allows you to specify the Arduino framework by setting `framework = arduino` in the `platformio.ini` file, ensuring better compatibility. Reviewing and adjusting platform-specific configurations can often solve the majority of issues when porting an Arduino project. For further assistance, PlatformIO’s extensive [documentation](https://docs.platformio.org/en/latest/) and community support are valuable resources.
+
+
+## Example
+
+This repository contains an example of a PlatformIO project. It is based on the Arduino example provided in the TTN Mapper project. The example is adapted to PlatformIO and the ESP32 platform.
+


### PR DESCRIPTION
The goal of this PR is to show it is possible to use PlatformIO as the IDE for this project. The main advantage is that PlatformIO allows to specify all libraries in a `.ini` file and it is better suited to manage a professional project. 

For this purpose a `platformio` directory has been created in the `example` directory with one of the existing examples converted.

I have tried it successfully on a Wireless Stick and Wireless Stick Lite and have added some rudimentary documentation. The changes are pretty small and self-explanatory.